### PR TITLE
Fix to prevent empty files from crashing JS Hint

### DIFF
--- a/src/main/resources/jshint.js
+++ b/src/main/resources/jshint.js
@@ -1008,7 +1008,7 @@ var JSHINT = (function () {
             var at,
                 tw; // trailing whitespace check
 
-            if (line >= lines.length)
+            if (lines != null && line >= lines.length)
                 return false;
 
             character = 1;
@@ -1093,6 +1093,10 @@ var JSHINT = (function () {
         // Public lex methods
         return {
             init: function (source) {
+                if (source == null) {
+                    return;
+                }
+                
                 if (typeof source === 'string') {
                     lines = source
                         .replace(/\r\n/g, '\n')


### PR DESCRIPTION
Previously, js hint would error out if the source was null.
